### PR TITLE
Initial start of passing in course description information automatically for Qualtrics survey XBlock. Planner Rm8eK7r-tkOu4CjdeWrJumQAPvl4

### DIFF
--- a/qualtricssurvey/models.py
+++ b/qualtricssurvey/models.py
@@ -2,12 +2,63 @@
 Handle data access logic for the XBlock
 """
 
+import six
+
 from django.utils.translation import ugettext_lazy as _
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from xblock.fields import Scope
-from xblock.fields import String
+from xblock.fields import Boolean, String
 
+class CourseDetailsXBlockMixin(object):
+    """
+    Handles all course related information from the platform.
+    """
+    @property
+    def course_id(self):
+        try:
+            raw_course_id = getattr(self.runtime, 'course_id', None)
+        except AttributeError:
+            return None
 
-class QualtricsSurveyModelMixin:
+        return str(raw_course_id)
+
+    @property
+    def course_name(self):
+        try:
+            raw_course_id = getattr(self.runtime, 'course_id', None) 
+        except AttributeError:
+            return None
+
+        return CourseOverview.get_from_id(raw_course_id).display_name
+
+    @property
+    def course_org(self):
+        try:
+            raw_course_id = getattr(self.runtime, 'course_id', None)
+        except AttributeError:
+            return None
+
+        return str(raw_course_id.org)
+
+    @property
+    def course_number(self):
+        try:
+            raw_course_id = getattr(self.runtime, 'course_id', None)
+        except AttributeError:
+            return None
+            
+        return str(raw_course_id.course)
+
+    @property
+    def course_run(self):
+        try:
+            raw_course_id = getattr(self.runtime, 'course_id', None)
+        except AttributeError:
+            return None           
+
+        return str(raw_course_id.run)
+    
+class QualtricsSurveyModelMixin(CourseDetailsXBlockMixin):
     """
     Handle data access for XBlock instances
     """
@@ -16,10 +67,72 @@ class QualtricsSurveyModelMixin:
         'display_name',
         'survey_id',
         'your_university',
-        'link_text',
-        'param_name',
+        # 'link_text',
+        # 'param_name',
         'message',
+        'course_id_override',
+        'course_name_override',
+        'course_org_override',
+        'course_number_override',
+        'course_run_override',
+        'course_term_override',
+        'show_meta_information',
     ]
+    course_id_override = String(
+        display_name=_('Course Identifier:'),
+        default='%%COURSE_ID%%',
+        scope=Scope.settings,
+        help=_(
+            'Enter in the Open edX course identifier override with '
+            'following format: {key type}:{org}+{course}+{run} (e.g. course-v1:edX+DemoX+2014) or {org}/{course}/{run} (e.g. edX/DemoX/2014). '
+            'Default value of %%COURSE_ID%% will pull automatically from the platform.'
+        ),
+    )
+    course_name_override = String(
+        display_name=_('Course Name:'),
+        default='%%COURSE_NAME%%',
+        scope=Scope.settings,
+        help=_(
+            'Enter in the Open edX course name override. '
+            'Default value of %%COURSE_NAME%% will pull automatically from the platform.'
+        ),
+    )
+    course_number_override = String(
+        display_name=_('Course Number:'),
+        default='%%COURSE_NUMBER%%',
+        scope=Scope.settings,
+        help=_(
+            'Enter in the Open edX course number override.'
+            'Default value of %%COURSE_NUMBER%% will pull automatically from the platform.'
+        ),
+    )
+    course_org_override = String(
+        display_name=_('Course Organization:'),
+        default='%%COURSE_ORG%%',
+        scope=Scope.settings,
+        help=_(
+            'Enter in the Open edX course organization override.'
+            'Default value of %%COURSE_ORG%% will pull automatically from the platform.'
+        ),
+    )
+    course_run_override = String(
+        display_name=_('Course Run:'),
+        default='%%COURSE_RUN%%',
+        scope=Scope.settings,
+        help=_(
+            'Enter in the Open edX course run override.'
+            'Default value of %%COURSE_RUN%% will pull automatically from the platform.'
+        ),
+    )
+    course_term_override = String(
+        display_name=_('Course Term:'),
+        default='perpetual',
+        scope=Scope.settings,
+        help=_(
+            'Enter in the Open edX course term override (e.g. "2019_Fall" or "2021_Spring").'
+            'Default value of %%COURSE_TERM%% will pull automatically from the platform.'
+        ),
+    )
     display_name = String(
         display_name=_('Display Name:'),
         default='Qualtrics Survey',
@@ -29,29 +142,38 @@ class QualtricsSurveyModelMixin:
             'of the page.'
         ),
     )
-    link_text = String(
-        display_name=_('Link Text:'),
-        default='Begin Survey',
-        scope=Scope.settings,
-        help=_('This is the text that will link to your survey.'),
-    )
+    # link_text = String(
+    #     display_name=_('Link Text:'),
+    #     default='Begin Survey',
+    #     scope=Scope.settings,
+    #     help=_('This is the text that will link to your survey.'),
+    # )
     message = String(
         display_name=_('Message:'),
-        default='The survey will open in a new browser tab or window.',
+        default='We need your help! Please take time now to complete this survey; your feedback '
+            'will help us improve this curriculum for other learners. Once you have completed '
+            'the survey please continue the course by clicking the next button. Thanks! ',
         scope=Scope.settings,
         help=_(
             'This is the text that will be displayed '
             'above the link to your survey.'
         ),
     )
-    param_name = String(
-        display_name=_('Param Name:'),
-        default='a',
+    # param_name = String(
+    #     display_name=_('Param Name:'),
+    #     default='a',
+    #     scope=Scope.settings,
+    #     help=_(
+    #         'This is the name for the User ID parameter in the url. '
+    #         'If blank, User ID is ommitted from the url.'
+    #     ),
+    # )
+    show_meta_information = Boolean(
+        display_name=_("Show Qualtrics Survey Meta Information"),
+        help=_("Displays 'meta' information about the survey to show query parameters passed. "
+               "A default value can be set in Advanced Settings."),
         scope=Scope.settings,
-        help=_(
-            'This is the name for the User ID parameter in the url. '
-            'If blank, User ID is ommitted from the url.'
-        ),
+        default=False
     )
     survey_id = String(
         display_name=_('Survey ID:'),
@@ -65,19 +187,98 @@ class QualtricsSurveyModelMixin:
     )
     your_university = String(
         display_name=_('Your University:'),
-        default='stanforduniversity',
+        default='clemson',
         scope=Scope.settings,
         help=_('This is the name of your university.'),
     )
 
     # pylint: disable=no-member
-    def get_anon_id(self):
+    # def get_anon_id(self):
+    #     """
+    #     Return an anonymous user id
+    #     """
+    #     try:
+    #         user_id = self.xmodule_runtime.anonymous_student_id
+    #     except AttributeError:
+    #         user_id = -1
+    #     return user_id
+
+    # pylint: disable=no-member
+    def get_course_id(self):
         """
-        Return an anonymous user id
+        Return the course_id of the course where this XBlock is used.
+        Substitute %%-encoded keywords in the XBlock field with actual string.
         """
-        try:
-            user_id = self.xmodule_runtime.anonymous_student_id
-        except AttributeError:
-            user_id = -1
-        return user_id
-    # pylint: enable=no-member
+        if self.course_id_override is not None and self.course_id is not None:
+            # Substitute all %%-encoded keywords in the message body
+            return six.text_type(six.moves.urllib.parse.quote(self.course_id_override.replace("%%COURSE_ID%%", self.course_id)))
+            
+        return six.text_type(six.moves.urllib.parse.quote(self.course_id_override))
+
+    # pylint: disable=no-member
+    def get_course_name(self):
+        """
+        Return the course_name of the course where this XBlock is used.
+        Substitute %%-encoded keywords in the XBlock field with actual string.
+        """
+        if self.course_name_override is not None and self.course_name is not None:
+            # Substitute all %%-encoded keywords in the message body
+            return six.text_type(six.moves.urllib.parse.quote(self.course_name_override.replace("%%COURSE_NAME%%", self.course_name)))
+
+        return self.course_name_override 
+
+    # pylint: disable=no-member
+    def get_course_org(self):
+        """
+        Return the course_org of the course where this XBlock is used.
+        Substitute %%-encoded keywords in the XBlock field with actual string.
+        """
+        if self.course_org_override is not None and self.course_org is not None:
+            # Substitute all %%-encoded keywords in the message body
+            return six.text_type(six.moves.urllib.parse.quote(self.course_org_override.replace("%%COURSE_ORG%%", self.course_org)))
+
+        return self.course_org_override
+
+    # pylint: disable=no-member
+    def get_course_number(self):
+        """
+        Return the course_number of the course where this XBlock is used.
+        Substitute %%-encoded keywords in the XBlock field with actual string.
+        """
+        if self.course_number_override is not None and self.course_number is not None:
+            # Substitute all %%-encoded keywords in the message body
+            return six.text_type(six.moves.urllib.parse.quote(self.course_number_override.replace("%%COURSE_NUMBER%%", self.course_number)))
+
+        return self.course_number_override
+
+    # pylint: disable=no-member
+    def get_course_run(self):
+        """
+        Return the course_run of the course where this XBlock is used.
+        Substitute %%-encoded keywords in the XBlock field with actual string.
+        """
+        if self.course_run_override is not None and self.course_run is not None:
+            # Substitute all %%-encoded keywords in the message body
+            return six.text_type(six.moves.urllib.parse.quote(self.course_run_override.replace("%%COURSE_RUN%%", self.course_run)))
+
+        return self.course_run_override
+
+    # pylint: disable=no-member
+    def get_course_term(self):
+        """
+        Return the course_term of the course where this XBlock is used.
+        Substitute %%-encoded keywords in the XBlock field with actual string.
+        """
+        if self.course_term_override is not None:
+            # Substitute all %%-encoded keywords in the message body
+            return six.text_type(six.moves.urllib.parse.quote(self.course_term_override))
+
+        return self.course_term_override
+
+    # pylint: disable=no-member
+    def should_show_meta_information(self):
+        """
+        Return True/False to indicate whether to show the "Show Qualtrics Survey Meta Information" information.
+        """
+        return self.show_meta_information
+

--- a/qualtricssurvey/public/view.css
+++ b/qualtricssurvey/public/view.css
@@ -3,3 +3,18 @@
 .qualtricssurvey_block .qualtrics-button:visited {
   /* This file intentionally left empty */
 }
+.qualtricssurvey_block .qualtrics-message {
+  border-left: 5px solid #74c4e1;
+  padding: 20px;
+  margin-bottom: 0px;
+  margin-top: 0px;
+  background-color: #eef2f4;
+}
+.qualtricssurvey_block .qualtrics-message p {
+  margin-bottom: 0px;
+}
+.qualtricssurvey_block iframe {
+  width: 100%;
+  height: 1000px;
+  border: 0px;
+}

--- a/qualtricssurvey/public/view.less
+++ b/qualtricssurvey/public/view.less
@@ -4,4 +4,22 @@
     .qualtrics-button:visited {
         /* This file intentionally left empty */
     }
+
+    .qualtrics-message {
+        border-left: 5px solid #74c4e1; 
+        padding: 20px; 
+        margin-bottom: 0px; 
+        margin-top: 0px; 
+        background-color: #eef2f4;
+
+        p {
+            margin-bottom: 0px;
+        }
+    }
+
+    iframe {
+        width: 100%; 
+        height: 1000px; 
+        border: 0px;
+    }
 }

--- a/qualtricssurvey/templates/view.html
+++ b/qualtricssurvey/templates/view.html
@@ -1,12 +1,18 @@
 <div class="qualtricssurvey_block">
+  <!--
     <p>{{message}}</p>
     <p>
         <a
           class="button primary-button qualtrics-button"
-          href="https://{{your_university}}.qualtrics.com/jfe/form/{{survey_id}}{{user_id_string}}"
+          href="https://{{your_university}}.qualtrics.com/jfe/form/{{survey_id}}?{{user_id_string}}"
           target="_blank"
         >
           {{link_text}}
         </a>
     </p>
+  -->
+    <div class="qualtrics-message">
+        <p>{{message}}</p>
+    </div>
+    <iframe src="https://{{your_university}}.ca1.qualtrics.com/jfe/form/{{survey_id}}?{{course_id_string}}&amp;{{course_name_string}}&amp;{{course_org_string}}&amp;{{course_number_string}}&amp;{{course_run_string}}&amp;{{course_term_string}}&amp;{{course_institution_string}}&amp;{{course_instructor_string}}&amp;{{show_meta_information_string}}" />
 </div>

--- a/qualtricssurvey/views.py
+++ b/qualtricssurvey/views.py
@@ -24,20 +24,65 @@ class QualtricsSurveyViewMixin(
         """
         context = context or {}
         context = dict(context)
-        param_name = self.param_name
-        anon_user_id = self.get_anon_id()
-        user_id_string = ''
-        if param_name:
-            user_id_string = ("?{param_name}={anon_user_id}").format(
-                param_name=param_name,
-                anon_user_id=anon_user_id,
-            )
+        # param_name = self.param_name
+        # anon_user_id = self.get_anon_id()
+        # user_id_string = ''
+        # if param_name:
+        #     user_id_string = ("{param_name}={anon_user_id}").format(
+        #         param_name=param_name,
+        #         anon_user_id=anon_user_id,
+        #     )
+        param_course_id = self.get_course_id()
+        course_id_string = ("course_id={param_course_id}").format(
+            param_course_id=param_course_id,
+        )
+        param_course_name = self.get_course_name()
+        course_name_string = ("course_name={param_course_name}").format(
+            param_course_name=param_course_name,
+        )
+        param_course_org = self.get_course_org()
+        course_org_string = ("course_org={param_course_org}").format(
+            param_course_org=param_course_org,
+        )
+        param_course_number = self.get_course_number()
+        course_number_string = ("course_number={param_course_number}").format(
+            param_course_number=param_course_number,
+        )
+        param_course_run = self.get_course_run() 
+        course_run_string = ("course_run={param_course_run}").format(
+            param_course_run=param_course_run,
+        )
+        param_course_term = self.get_course_term()
+        course_term_string = ("course_term={param_course_term}").format(
+            param_course_term=param_course_term,
+        )
+        param_course_institution = ''
+        course_institution_string = ("course_institution={param_course_institution}").format(
+            param_course_institution=param_course_institution,
+        )
+        param_course_instructor = ''
+        course_instructor_string = ("course_instructor={param_course_instructor}").format(
+            param_course_instructor=param_course_instructor,
+        )
+        param_display_meta = '1' if self.should_show_meta_information() else '0'
+        show_meta_information_string = ("display_meta={param_display_meta}").format(
+            param_display_meta=param_display_meta,
+        )
         context.update({
             'xblock_id': str(self.scope_ids.usage_id),
             'survey_id': self.survey_id,
             'your_university': self.your_university,
-            'link_text': self.link_text,
-            'user_id_string': user_id_string,
+            # 'link_text': self.link_text,
+            # 'user_id_string': user_id_string,
+            'course_id_string': course_id_string,
+            'course_name_string': course_name_string,
+            'course_org_string': course_org_string,
+            'course_number_string': course_number_string,
+            'course_run_string': course_run_string,
+            'course_term_string': course_term_string,
+            'course_institution_string': course_institution_string,
+            'course_instructor_string': course_instructor_string,
+            'show_meta_information_string': show_meta_information_string,
             'message': self.message,
         })
         return context


### PR DESCRIPTION
Modified Stanford Online's base code to accommodate the changes needed for EducateWorkforce. 

Todo: Everything seems to work for Pre/Post-Course Surveys, however we need to go back and pass additional parameters for Post-Module Survey. Also need to decide what additional `CourseOverview` meta information that we'd like to pass on (e.g. `start_date`, `end_date`). 