### PR TITLE
feat(qualtrics): Push out platform user PII information to Qualtrics.

### DIFF
--- a/qualtricssurvey/models.py
+++ b/qualtricssurvey/models.py
@@ -181,7 +181,69 @@ class CourseDetailsXBlockMixin(object):
         institution, instructors, term = self._get_context_course_advanced_settings(src_block)
         return term
 
-class QualtricsSurveyModelMixin(CourseDetailsXBlockMixin):
+
+class UserDetailsXBlockMixin(object):
+    """
+    Handles all course related information from the platform.
+    """
+
+    @property
+    def get_anon_id(self):
+        """
+        Return an anonymous user id
+        """
+        try:
+            user_id = self.xmodule_runtime.anonymous_student_id
+        except AttributeError:
+            user_id = -1
+        return user_id
+
+    @property
+    def get_username(self):
+        """
+        Return the real user's username
+        """
+        try:
+            username = self.xmodule_runtime._services.get('user').get_current_user().opt_attrs['edx-platform.username']
+        except AttributeError:
+            username = ""
+        return username
+
+    @property
+    def get_fullname(self):
+        """
+        Return the real user's fullname
+        """
+        try:
+            user_fullname = self.xmodule_runtime._services.get('user').get_current_user().full_name
+        except AttributeError:
+            user_fullname = ""
+        return user_fullname
+
+    @property
+    def get_email(self):
+        """
+        Return the real user's email
+        """
+        try:
+            user_email = self.xmodule_runtime._services.get('user').get_current_user().emails[0]
+        except AttributeError:
+            user_email = ""
+        return user_email
+
+    @property
+    def get_user_is_staff(self):
+        """
+        Return whether the real user is staff member or not.
+        """
+        try:
+            user_is_staff = self.xmodule_runtime.user_is_staff
+        except AttributeError:
+            user_is_staff = False
+        return user_is_staff
+
+
+class QualtricsSurveyModelMixin(CourseDetailsXBlockMixin, UserDetailsXBlockMixin):
     """
     Handle data access for XBlock instances
     """
@@ -203,6 +265,7 @@ class QualtricsSurveyModelMixin(CourseDetailsXBlockMixin):
         'course_end_date_override',
         'course_institution_override',
         'course_instructors_override',
+        'forward_platform_user_pii',
         'show_simulation_exists',
         'show_meta_information',
     ]
@@ -322,6 +385,13 @@ class QualtricsSurveyModelMixin(CourseDetailsXBlockMixin):
     #         'If blank, User ID is ommitted from the url.'
     #     ),
     # )
+    forward_platform_user_pii = Boolean(
+        display_name=_("Forward Platform User PII to Qualtrics"),
+        help=_("Sends personal information (username, full name, email) about the platform user account to Qualtrics. "
+               "This is disabled by default."),
+        scope=Scope.settings,
+        default=False
+    )
     show_simulation_exists = Boolean(
         display_name=_("Simulation Exists"),
         help=_("Displays simulation questions from the survey when the query parameters is passed. "
@@ -477,12 +547,17 @@ class QualtricsSurveyModelMixin(CourseDetailsXBlockMixin):
         """
         return self.module_name
 
+    def should_forward_platform_user_pii(self):
+        """
+        Return True/False to indicate whether to forward the "Forward Platform User PII to Qualtrics" information.
+        """
+        return self.forward_platform_user_pii
+
     def should_show_simulation_exists(self):
         """
         Return True/False to indicate whether to show the "Simulation Exists" questions.
         """
         return self.show_simulation_exists
-
 
     # pylint: disable=no-member
     def should_show_meta_information(self):

--- a/qualtricssurvey/templates/view.html
+++ b/qualtricssurvey/templates/view.html
@@ -14,5 +14,5 @@
     <div class="qualtrics-message">
         <p>{{message}}</p>
     </div>
-    <iframe src="https://{{your_university}}.qualtrics.com/jfe/form/{{survey_id}}?{{course_id_string}}&amp;{{course_name_string}}&amp;{{course_org_string}}&amp;{{course_number_string}}&amp;{{course_run_string}}&amp;{{course_term_string}}&amp;{{course_start_date_string}}&amp;{{course_end_date_string}}&amp;{{course_institution_string}}&amp;{{course_instructor_string}}&amp;{{course_module_name_string}}&amp;{{show_simulation_exists_string}}&amp;{{show_meta_information_string}}" />
+    <iframe src="https://{{your_university}}.qualtrics.com/jfe/form/{{survey_id}}?{{course_id_string}}&amp;{{course_name_string}}&amp;{{course_org_string}}&amp;{{course_number_string}}&amp;{{course_run_string}}&amp;{{course_term_string}}&amp;{{course_start_date_string}}&amp;{{course_end_date_string}}&amp;{{course_institution_string}}&amp;{{course_instructor_string}}&amp;{{course_module_name_string}}&amp;{{forward_platform_user_pii}}&amp;{{show_simulation_exists_string}}&amp;{{show_meta_information_string}}" />
 </div>

--- a/qualtricssurvey/views.py
+++ b/qualtricssurvey/views.py
@@ -76,6 +76,20 @@ class QualtricsSurveyViewMixin(
         course_module_name_string = ("module_name={param_course_module_name}").format(
             param_course_module_name=param_course_module_name,
         )
+        param_display_simulation_exists = '1' if self.should_forward_platform_user_pii() else '0'
+        show_simulation_exists_string = ("simulation_exists={param_display_simulation_exists}").format(
+            param_display_simulation_exists=param_display_simulation_exists,
+        )
+        forward_platform_user_pii_string = ""
+        if self.should_forward_platform_user_pii():
+            forward_platform_user_pii_string = (
+                "platform_username={param_platform_username}&platform_fullname={param_platform_fullname}&platform_email={param_platform_email}&platform_user_is_staff={param_platform_user_is_staff}").format(
+                    param_platform_username=self.get_username,
+                    param_platform_fullname=self.get_fullname,
+                    param_platform_email=self.get_email,
+                    param_platform_user_is_staff = self.get_user_is_staff
+            )
+
         param_display_simulation_exists = '1' if self.should_show_simulation_exists() else '0'
         show_simulation_exists_string = ("simulation_exists={param_display_simulation_exists}").format(
             param_display_simulation_exists=param_display_simulation_exists,
@@ -101,6 +115,7 @@ class QualtricsSurveyViewMixin(
             'course_instructor_string': course_instructor_string.strip(),
             'course_module_name_string': course_module_name_string.strip(),
             #'course_module_id_string': self.module_id.strip(),
+            'forward_platform_user_pii': forward_platform_user_pii_string.strip(),
             'show_simulation_exists_string': show_simulation_exists_string.strip(),
             'show_meta_information_string': show_meta_information_string.strip(),
             'message': self.message,


### PR DESCRIPTION
Need to find a way to push platform Personal Identifiable Information (PII) to the Qualtrics service. This option is disabled by default to limit exposure to user information being stored on third-party services and the GDPR concern. 