### PR TITLE
feat(qualtrics): Update `raw_earned / raw_possible` score to account for Qualtrics score.

### DIFF
--- a/qualtricssurvey/models.py
+++ b/qualtricssurvey/models.py
@@ -302,6 +302,7 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, U
         'course_institution_override',
         'course_instructors_override',
         'forward_platform_user_pii',
+        'send_qualtrics_score_to_platform',
         'show_simulation_exists',
         'show_meta_information',
         'weight'
@@ -429,6 +430,13 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, U
         scope=Scope.settings,
         default=False
     )
+    send_qualtrics_score_to_platform = Boolean(
+        display_name=_("Send Qualtrics Score to Platform"),
+        help=_("When enabled this sends the qualtrics score value from learner's response."
+               "This is disabled by default. Only enable this when scoring is setup in the survey"),
+        scope=Scope.settings,
+        default=False
+    )
     show_simulation_exists = Boolean(
         display_name=_("Simulation Exists"),
         help=_("Displays simulation questions from the survey when the query parameters is passed. "
@@ -462,9 +470,10 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, U
 
     weight = Float(
         display_name=_("Problem Weight"),
-        default=0,
         help=_("Defines the number of points each problem is worth. "
-               "If the value is not set, each response field in the problem is worth one point."),
+               "If the value is not set, each response field in the problem is worth one point. "
+               "Whenever 'Send Qualtrics Score to Platform' is set this weight is not used but rather Qualtrics defines the weight based on score settings."
+        ),
         values={"min": 0, "step": .1},
         scope=Scope.settings
     )
@@ -621,6 +630,12 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, U
         """
         return self.forward_platform_user_pii
 
+    def should_send_qualtrics_score_to_platform(self):
+        """
+        Return True/False to indicate whether to "Send Qualtrics Score to Platform" information.
+        """
+        return self.send_qualtrics_score_to_platform
+
     def should_show_simulation_exists(self):
         """
         Return True/False to indicate whether to show the "Simulation Exists" questions.
@@ -630,31 +645,60 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, U
     def get_survey_id(self) :
         return self.survey_id
 
-
     # pylint: disable=no-member
     def should_show_meta_information(self):
         """
         Return True/False to indicate whether to show the "Show Qualtrics Survey Meta Information" information.
         """
         return self.show_meta_information
-              
+    
     def max_score(self):
         """
         Return the weight of the problem. This method is in the staff debug information
         """
-        return self.weight
+
+        # Exit early because we already have a score and we don't want to pull from the
+        # defaults set in the rest of this method. If we don't do this check and the max score 
+        # changes either through weight or Qualtrics score (adding/removing new problems) then
+        # the previous user experience could change with `raw_possible`.
+        if self.score is not None:
+            return self.score.raw_possible
+
+        raw_possible = 0.0
+
+        if self.should_send_qualtrics_score_to_platform():
+            # Find score values from Qualtrics
+
+            # Get the number of questions from the Qualtrics Survey Definition Questions
+            # endpoint and find all questions with score value set.
+            response_survey_questions = QualtricsApi().get_survey_definition_questions(self.get_survey_id())
+
+            if response_survey_questions.ok:
+                data_response_survey_questions = response_survey_questions.json()
+                result = data_response_survey_questions["result"]
+                elements = result["elements"]
+
+                for question in elements:
+                    if question["GradingData"]:
+                        raw_possible += float(question["GradingData"][0]["Grades"][settings.QUALTRICS_SCORE_ID])
+        else:
+            # Awards full points for completing a survey (default)
+            raw_possible = (self.weight if self.weight is not None and self.weight > 0 else 1.0)
+
+        return raw_possible
 
     @XBlock.json_handler
     def get_survey_status(self, data, suffix=''):
         # Prevents dividing by zero when computing weighted score for unweighted survey
-        if (self.score is not None and self.score.raw_possible != 0):
-            earned_score = (self.score.raw_earned/self.score.raw_possible) * self.weight
-        else: 
-            earned_score = 0
 
-        return {'is_answered': self.is_answered, 'max_score': self.weight, 'earned_score': earned_score}
+        if self.score:
+            raw_earned = self.score.raw_earned
+            raw_possible = self.score.raw_possible
+        else:
+            raw_earned = raw_possible = 0
         
-
+        return {'is_answered': self.is_answered, 'possible_score': raw_possible, 'earned_score': raw_earned}
+        
     @QualtricsHandlersMixin.x_www_form_handler
     def end_survey(self, data, suffix=''):  # pylint: disable=unused-argument
         """
@@ -679,21 +723,36 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, U
                     import_error_anonymous_id
                 }
             else:
-                real_user = user_by_anonymous_id(values["anonymous_user_id"])
-                if (real_user is None):
-                    real_user_error = u"Cannot find `real_user` from the `anonymous_user_id`."
-                    LOGGER.error(real_user_error)
-                    raise ValueError(real_user_error)
+                # Only update learner's score if we have an `anonymous_user_id`` to
+                # map to a `real` user. This `anonymous_user_id` was passed to the
+                # Qualtrics survey as query parameter and was meant to prevent 
+                # external system (e.g. Qualtrics) from keeping PII information for
+                # a platform user account. Since then we have created an component
+                # option to `Forward Platform User PII to Qualtrics` which does send
+                # PII information over to Qualtrics which was a request from the
+                # research team.
+                if 'platform_anonymous_user_id' in values:
+                    real_user = user_by_anonymous_id(values["platform_anonymous_user_id"])
+                    if (real_user is None):
+                        real_user_error = u"Cannot find `real_user` from the `platform_anonymous_user_id`."
+                        LOGGER.error(real_user_error)
+                        raise ValueError(real_user_error)
 
-                # rebinds the user to the xblock so that a grade can be published for the correct user
-                self.system.rebind_noauth_module_to_user(self, real_user)
+                    # rebinds the user to the xblock so that a grade can be published for the correct user
+                    self.system.rebind_noauth_module_to_user(self, real_user)
 
-                score = self.calculate_score()
-                self.set_score(score)
-                self.publish_grade()
-            
-                # Updates database survey status to complete
-                self.is_answered = True
+                    score = self.calculate_score(values)
+                    self.set_score(score)
+                    self.publish_grade()
+                
+                    # Updates database survey status to complete
+                    self.is_answered = True
+                else:
+                    LOGGER.warning(
+                        "Could not update the learner's score because the"
+                        "`platform_anonymous_user_id` value was not found in the"
+                        "Qualtrics survey response."
+                    )
 
         response = {
             "Message": "Data processed from the Qualtrics Event Subscription API postback `surveyengine.completedResponse` event."
@@ -701,11 +760,17 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, U
         return response
 
     def publish_grade(self):
-        grade_dict = {
-            'value': self.score.raw_earned,
-            'max_value': self.score.raw_possible,
-        }
-        self.runtime.publish(self, "grade", grade_dict)
+        """
+        Update the learner's course score for this Qualtrics component so the
+        grade is reflected on the gradebook.
+        """
+
+        if self.score:
+            grade_dict = {
+                'value': self.score.raw_earned,
+                'max_value': self.score.raw_possible,
+            }
+            self.runtime.publish(self, "grade", grade_dict)
 
     def has_submitted_answer(self):
         return self.is_answered
@@ -721,12 +786,22 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, U
         """
         Returns the score currently set on the block.
         """
-        return self.score
+        return (self.score if self.score else None)
 
-    def calculate_score(self):
+    def calculate_score(self, values):
         """
         Returns the score calculated from the current problem state.
+        This varies based on the XBlock setting for `Send Qualtrics Score to Platform`.
         """
-        # Awards full points for completing a survey
-        earned_score = 1
-        return Score(raw_earned=earned_score, raw_possible=1)
+        raw_earned = 0.0
+        raw_possible = self.max_score()
+
+        if self.should_send_qualtrics_score_to_platform():
+            # Find score values from Qualtrics
+            if values is not None:
+                raw_earned = float(values[settings.QUALTRICS_SCORE_ID])
+        else:
+            # Awards full points for completing a survey (default)
+            raw_earned = (self.weight if self.weight is not None and self.weight > 0 else 1.0)
+
+        return Score(raw_earned=raw_earned, raw_possible=raw_possible)

--- a/qualtricssurvey/public/view.js
+++ b/qualtricssurvey/public/view.js
@@ -22,7 +22,7 @@ function QualtricsSurveyView(runtime, element) {
   // var myElement = $element.find('.myElement');
   
   var earned_score_html = $('.qualtricssurvey_block .qualtrics_message .grade .earned_score')
-  var max_score_html = $('.qualtricssurvey_block .qualtrics_message .grade .max_score')
+  var possible_score_html = $('.qualtricssurvey_block .qualtrics_message .grade .possible_score')
   var status_html = $('.qualtricssurvey_block .qualtrics_message .grade .status')
   var graded_html = $('.qualtricssurvey_block .qualtrics_message .grade .is_graded')
   
@@ -40,7 +40,7 @@ function QualtricsSurveyView(runtime, element) {
           success: function (data) {
             if (data.is_answered == true) {
               $element.find(earned_score_html).text(data.earned_score.toFixed(1))
-              $element.find(max_score_html).text(data.max_score.toFixed(1))
+              $element.find(possible_score_html).text(data.possible_score.toFixed(1))
               $element.find(status_html).addClass("fa fa-check-circle graded")
             }
             else {

--- a/qualtricssurvey/qualtrics_api.py
+++ b/qualtricssurvey/qualtrics_api.py
@@ -71,6 +71,14 @@ class QualtricsApi():
         return "{}/{}".format(self._api_base_url, "surveys")
 
     @lazy
+    def _api_survey_definitions_base_url(self):
+        """
+        Base URL for surveys-definitions requests.
+        """
+
+        return "{}/{}".format(self._api_base_url, "survey-definitions")
+
+    @lazy
     def _site_prefix(self):
         """
         Get the prefix for the site URL-- protocol.
@@ -120,9 +128,28 @@ class QualtricsApi():
             subscription_id = response.json()['result']['id']
             return subscription_id
         
-        LOGGER.error(u"Could not create a subscription from Qualtrics API for course {} - XBlock location {}".format(course_id, xblock.location))
+        LOGGER.error(u"QualtricsApi – Could not create a subscription from Qualtrics API for course {} - XBlock location {}".format(course_id, xblock.location))
 
         return None
+
+    def get_survey_definition_questions(self, survey_id):
+        """
+        Retrieve survey definition questions
+        https://api.qualtrics.com/957c5f8a4604b-get-questions
+        """
+
+        url = "{}/{}/questions".format(self._api_survey_definitions_base_url, survey_id)
+
+        payload = {}
+        headers = self.get_headers()
+       
+        try:
+            response_survey_questions = requests.request("GET", url, headers=headers, data=payload)
+            self._log_if_raised(response_survey_questions, payload)
+        except:
+            LOGGER.error(u"QualtricsApi – Issue with get_survey_definition_questions() – Survey ID ({})".format(survey_id)) 
+
+        return response_survey_questions
 
     def get_survey_response(self, survey_id, response_id):
         """
@@ -134,8 +161,11 @@ class QualtricsApi():
         payload = {}
         headers = self.get_headers()
        
-        response_survey = requests.request("GET", url, headers=headers, data=payload)
-        self._log_if_raised(response_survey, payload)
+        try:
+            response_survey = requests.request("GET", url, headers=headers, data=payload)
+            self._log_if_raised(response_survey, payload)
+        except:
+            LOGGER.error(u"QualtricsApi – Issue with get_survey_response() – Survey ID ({}) – Response ID ({})".format(survey_id, response_id)) 
 
         return response_survey
 
@@ -154,7 +184,7 @@ class QualtricsApi():
 
             payload= {
                 'grant_type': 'client_credentials',
-                'scope': 'write:subscriptions read:survey_responses'
+                'scope': 'write:subscriptions read:survey_responses read:surveys'
                 }
 
             response = requests.post(self._api_auth_url, auth=(client_id, client_secret), data=payload)

--- a/qualtricssurvey/templates/view.html
+++ b/qualtricssurvey/templates/view.html
@@ -1,7 +1,7 @@
 <div class="qualtricssurvey_block">
     <div class="qualtrics_message"> 
         <div class="grade">
-          <span class="earned_score">{{earned_score}}</span>/<span class="max_score">{{max_score}}</span> points 
+          <span class="earned_score">{{earned_score}}</span>/<span class="possible_score">{{possible_score}}</span> points 
           <span class = "is_graded"></span><span class="status"></span>
         </div>
         <p>{{message}}</p>

--- a/qualtricssurvey/views.py
+++ b/qualtricssurvey/views.py
@@ -29,7 +29,7 @@ class QualtricsSurveyViewMixin(
         context = dict(context)
     
         anon_user_id = self.get_anon_id()
-        anon_user_id_string = ("anonymous_user_id={anon_user_id}").format(
+        anon_user_id_string = ("platform_anonymous_user_id={anon_user_id}").format(
             anon_user_id=anon_user_id,
         )
         param_course_id = self.get_course_id()
@@ -120,8 +120,8 @@ class QualtricsSurveyViewMixin(
             'message': self.message,
             'survey_completed': param_survey_completed,
             'anon_user_id_string': anon_user_id_string,
-            'earned_score': self.score.raw_earned*self.weight if self.score is not None else 0,
-            'max_score': self.max_score,
+            'earned_score': self.score.raw_earned if self.score is not None else 0.0,
+            'possible_score': self.max_score(),
         })
         
         return context


### PR DESCRIPTION
We defined a component option `Send Qualtrics Score to Platform` that when enabled will update the possible score for the learner to account for Qualtrics score.

By default this option is disabled and then the score uses the weight component field (defaults to 1 point if not defined).

Need to update the OAuth client scope with `read:surveys` https://clemson.ca1.qualtrics.com/oauth-client-manager/ to accommodate for use of this additional Qualtrics API endpoint (https://api.qualtrics.com/957c5f8a4604b-get-questions) to pull back and find all score values set for the survey and aggregate them.

Only update the OAuth client scope whenever we push this out to production environment because the existing scope for production to retrieve the Bearer token is different and therefore all Qualtrics API calls will fail if this scope is set early.

Must also set the `settings.QUALTRICS_SCORE_ID` value in Site Configuration to account for different Qualtric endpoints like (e.g. `clemson.ca1` - Clemson, `utsa.az1` - Trustworks). This `Scoring Id` is defined by Qualtrics https://api.qualtrics.com/733ad3c0151de-scoring-id and is unique per their sites.