### PR TITLE
Make sure the default `points_possible` is zero and fix graded state using XBlock runtime value for the `maple` release.

### DIFF
--- a/qualtricssurvey/models.py
+++ b/qualtricssurvey/models.py
@@ -593,7 +593,7 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, U
     weight = Float(
         display_name=_("Problem Weight"),
         help=_("Defines the number of points each problem is worth. "
-               "If the value is not set, each response field in the problem is worth one point. "
+               "If the value is not set, each response field in the problem is worth zero points. "
                "Whenever 'Send Qualtrics Score to Platform' is set this weight is not used but rather Qualtrics defines the weight based on score settings."
         ),
         values={"min": 0, "step": .1},
@@ -841,7 +841,7 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, U
                         raw_possible += float(question["GradingData"][0]["Grades"][self.get_survey_score_id()])
         else:
             # Awards full points for completing a survey (default)
-            raw_possible = (self.weight if self.weight is not None and self.weight > 0 else 1.0)
+            raw_possible = (self.weight if self.weight is not None and self.weight > 0 else 0.0)
 
         return raw_possible
 

--- a/qualtricssurvey/models.py
+++ b/qualtricssurvey/models.py
@@ -846,6 +846,11 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, U
         return raw_possible
 
     @XBlock.json_handler
+    def is_graded(self, data, suffix=''):
+        # Returns if the survey is graded or not. Used on the Javscript file to loaded graded status.
+        return {'graded': self.graded}
+
+    @XBlock.json_handler
     def get_survey_status(self, data, suffix=''):
         # Prevents dividing by zero when computing weighted score for unweighted survey
 

--- a/qualtricssurvey/static/js/view.js
+++ b/qualtricssurvey/static/js/view.js
@@ -28,28 +28,42 @@ function QualtricsSurveyView(runtime, element) {
   
   var handlerUrl = runtime.handlerUrl(element, 'get_survey_status');
 
-  var graded = $element.context.getAttribute('data-graded') === 'True' ? '(Graded) ' : '(Ungraded) ';
-  $element.find(graded_html).text(graded)
-
-    function updateView(event) {
-      setTimeout(function() { 
-        $.ajax({
-          method: "POST",
-          url: handlerUrl,
-          data: JSON.stringify({}),
-          success: function (data) {
-            if (data.is_answered == true) {
-              $element.find(earned_score_html).text(data.earned_score.toFixed(1))
-              $element.find(possible_score_html).text(data.possible_score.toFixed(1))
-              $element.find(status_html).addClass("fa fa-check-circle graded")
-            }
-            else {
-              updateView()
-            }
-          }
-        });
-      }, 3000)
-    }
-
-    updateView();
+  /* Set the graded status for the xblock */
+  function updateGradedStatus() {
+    $.ajax({
+        type: 'POST',
+        url: runtime.handlerUrl(element, 'is_graded'),
+        data: '{}',
+        success: function (data) {
+          $element.find(graded_html).text(
+            data.graded ? '(Graded) ' : '(Ungraded) ' 
+          );
+        },
+        dataType: 'json'
+    });
   }
+
+  /* Regularly check to see if score was received and display to the learner */
+  function updateView(event) {
+    setTimeout(function() { 
+      $.ajax({
+        method: "POST",
+        url: handlerUrl,
+        data: JSON.stringify({}),
+        success: function (data) {
+          if (data.is_answered == true) {
+            $element.find(earned_score_html).text(data.earned_score.toFixed(1))
+            $element.find(possible_score_html).text(data.possible_score.toFixed(1))
+            $element.find(status_html).addClass("fa fa-check-circle graded")
+          }
+          else {
+            updateView()
+          }
+        }
+      });
+    }, 3000)
+  }
+
+  updateGradedStatus();
+  updateView();
+}


### PR DESCRIPTION
An instructor wanted the default points to be zero to avoid having to manually set the grades for their students. Setting the `points_possible` to zero avoids having to do this additional step.

Support Ticket
https://educateworkforce.zendesk.com/agent/tickets/637