### PR TITLE
Ensure that the advanced settings for `Course Instructor` and `Other Course Settings` are handled if emtpy JSON.

### DIFF
--- a/qualtricssurvey/models.py
+++ b/qualtricssurvey/models.py
@@ -57,21 +57,30 @@ class CourseDetailsXBlockMixin(object):
         Return CMS Advanced Settings
         """
         block_iter = block
-        qs_course_instructor = 'None'
-        qs_course_term = 'perpetual'
+        # Use empty string defaults so missing keys/attributes result in empty string instead of raising.
+        qs_course_instructor = ''
+        qs_course_term = ''
 
         qs_course_id = self.course_id
 
         while block_iter:
-            block_iter_type = block_iter.scope_ids.block_type
-            if block_iter_type == 'course':  
-                qs_course_instructor = block_iter.instructor_info['instructors']
+            block_iter_type = getattr(block_iter.scope_ids, 'block_type', None)
+            if block_iter_type == 'course':
+                # Safely access instructor_info and other_course_settings without raising KeyError
                 try:
-                    qs_course_term = block_iter.other_course_settings['qualtrics_term']
-                except:
-                    LOGGER.error("QualtricsXblock – No qualtrics term found in other_course_settings")
-            
-            block_iter = block_iter.get_parent() if block_iter.parent else None
+                    instructor_info = getattr(block_iter, 'instructor_info', {}) or {}
+                    qs_course_instructor = instructor_info.get('instructors', '')
+                except Exception:
+                    qs_course_instructor = ''
+
+                try:
+                    other_settings = getattr(block_iter, 'other_course_settings', {}) or {}
+                    qs_course_term = other_settings.get('qualtrics_term', '')
+                except Exception:
+                    qs_course_term = ''
+                    LOGGER.error("QualtricsXblock - No qualtrics term found in other_course_settings")
+
+            block_iter = block_iter.get_parent() if getattr(block_iter, 'parent', None) else None
 
         return qs_course_instructor, qs_course_term
 


### PR DESCRIPTION
Received a KeyError when trying to access an empty `Course Intructor` JSON format on the Course Advanced Settings page.

```
cms-1  | 2025-11-12 20:53:25,618 INFO 269 [celery_utils.logged_task] [user 4] [ip 192.168.65.1] logged_task.py:25 - Task openedx.core.djangoapps.content.search.tasks.upsert_xblock_index_doc[a3bbc536-e1f6-4546-a4dc-e2859af28f72] submitted with arguments ('block-v1:BristowHS+FAA-ACS-AM-IC-WAB+2025_2026+type@about+block@video',), {'recursive': True}
cms-1  | 2025-11-12 20:53:25,704 ERROR 269 [root] [user None] [ip None] signals.py:22 - Uncaught exception from None
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/fields.py", line 446, in get_attribute
cms-1  |     return get_attribute(instance, self.source_attrs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/fields.py", line 99, in get_attribute
cms-1  |     if is_simple_callable(instance):
cms-1  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/fields.py", line 67, in is_simple_callable
cms-1  |     raise BuiltinSignatureError(
cms-1  | rest_framework.fields.BuiltinSignatureError: Built-in function signatures are not inspectable. Wrap the function call in a simple, pure Python function.
cms-1  | 
cms-1  | During handling of the above exception, another exception occurred:
cms-1  | 
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
cms-1  |     response = get_response(request)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
cms-1  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/opt/pyenv/versions/3.11.8/lib/python3.11/contextlib.py", line 81, in inner
cms-1  |     return func(*args, **kwds)
cms-1  |            ^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
cms-1  |     return view_func(*args, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/views/generic/base.py", line 104, in view
cms-1  |     return self.dispatch(request, *args, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
cms-1  |     response = self.handle_exception(exc)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
cms-1  |     response = handler(request, *args, **kwargs)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/lib/api/view_utils.py", line 438, in wrapped_function
cms-1  |     return view_func(self, request, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py", line 155, in put
cms-1  |     return Response(serializer.data)
cms-1  |                     ^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 555, in data
cms-1  |     ret = super().data
cms-1  |           ^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 253, in data
cms-1  |     self._data = self.to_representation(self.instance)
cms-1  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 522, in to_representation
cms-1  |     ret[field.field_name] = field.to_representation(attribute)
cms-1  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 522, in to_representation
cms-1  |     ret[field.field_name] = field.to_representation(attribute)
cms-1  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 686, in to_representation
cms-1  |     return [
cms-1  |            ^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 687, in <listcomp>
cms-1  |     self.child.to_representation(item) for item in iterable
cms-1  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 509, in to_representation
cms-1  |     attribute = field.get_attribute(instance)
cms-1  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/fields.py", line 458, in get_attribute
cms-1  |     raise type(exc)(msg)
cms-1  | rest_framework.fields.BuiltinSignatureError: Field source for `InstructorInfoSerializer.title` maps to a built-in function type and is invalid. Define a property or method on the `str` instance that wraps the call to the built-in function.
cms-1  | Internal Server Error: /api/contentstore/v1/course_details/course-v1:BristowHS+FAA-ACS-AM-IC-WAB+2025_2026
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/fields.py", line 446, in get_attribute
cms-1  |     return get_attribute(instance, self.source_attrs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/fields.py", line 99, in get_attribute
cms-1  |     if is_simple_callable(instance):
cms-1  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/fields.py", line 67, in is_simple_callable
cms-1  |     raise BuiltinSignatureError(
cms-1  | rest_framework.fields.BuiltinSignatureError: Built-in function signatures are not inspectable. Wrap the function call in a simple, pure Python function.
cms-1  | 
cms-1  | During handling of the above exception, another exception occurred:
cms-1  | 
cms-1  | Traceback (most recent call last):
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
cms-1  |     response = get_response(request)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
cms-1  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/opt/pyenv/versions/3.11.8/lib/python3.11/contextlib.py", line 81, in inner
cms-1  |     return func(*args, **kwds)
cms-1  |            ^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
cms-1  |     return view_func(*args, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/django/views/generic/base.py", line 104, in view
cms-1  |     return self.dispatch(request, *args, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
cms-1  |     response = self.handle_exception(exc)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
cms-1  |     response = handler(request, *args, **kwargs)
cms-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/openedx/core/lib/api/view_utils.py", line 438, in wrapped_function
cms-1  |     return view_func(self, request, **kwargs)
cms-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/edx-platform/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py", line 155, in put
cms-1  |     return Response(serializer.data)
cms-1  |                     ^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 555, in data
cms-1  |     ret = super().data
cms-1  |           ^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 253, in data
cms-1  |     self._data = self.to_representation(self.instance)
cms-1  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 522, in to_representation
cms-1  |     ret[field.field_name] = field.to_representation(attribute)
cms-1  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 522, in to_representation
cms-1  |     ret[field.field_name] = field.to_representation(attribute)
cms-1  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 686, in to_representation
cms-1  |     return [
cms-1  |            ^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 687, in <listcomp>
cms-1  |     self.child.to_representation(item) for item in iterable
cms-1  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 509, in to_representation
cms-1  |     attribute = field.get_attribute(instance)
cms-1  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1  |   File "/openedx/venv/lib/python3.11/site-packages/rest_framework/fields.py", line 458, in get_attribute
cms-1  |     raise type(exc)(msg)
cms-1  | rest_framework.fields.BuiltinSignatureError: Field source for `InstructorInfoSerializer.title` maps to a built-in function type and is invalid. Define a property or method on the `str` instance that wraps the call to the built-in function.
cms-1  | 2025-11-12 20:53:25,742 ERROR 269 [django.request] [user None] [ip None] log.py:241 - Internal Server Error: /api/contentstore/v1/course_details/course-v1:BristowHS+FAA-ACS-AM-IC-WAB+2025_2026
```