### PR TITLE
Handled KeyError for multiple Score categories when looking for key `SC_8Joxltl97oYWdAa` which represents the `Score` category for Teak.

### DIFF
--- a/qualtricssurvey/models.py
+++ b/qualtricssurvey/models.py
@@ -967,7 +967,11 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, O
                                 raw_possible += float(grade_data["Grades"][self.get_survey_score_id()])
                             except ValueError as err:
                                 # Sometimes we may forget to set a score grading value and `#` will get passed from Qualtrics.
-                                LOGGER.warning(u"Qualtrics – max_score() – Issue with getting raw_possible for – Survey ID ({}) QID ({}) GradingData({}) – {}".format(self.get_survey_id(), question["QuestionID"], grade_data["Grades"][self.get_survey_score_id()], err))
+                                LOGGER.warning(u"Qualtrics - max_score() - Issue with getting raw_possible for – Survey ID ({}) QID ({}) GradingData({}) – {}".format(self.get_survey_id(), question["QuestionID"], grade_data["Grades"][self.get_survey_score_id()], err))
+                                continue
+                            except KeyError as err:
+                                # Sometimes we may forget to set a score grading value and `#` will get passed from Qualtrics.
+                                LOGGER.warning(u"Qualtrics - max_score() - Issue with getting raw_possible for – Survey ID ({}) QID ({}) – {}".format(self.get_survey_id(), question["QuestionID"], err))
                                 continue
         else:
             # Awards full points for completing a survey (default)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from os import path, walk
 from setuptools import find_packages, setup
 
 
-version = '2.1.3'
+version = '2.1.4'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:


### PR DESCRIPTION
When adding additional survey score categories, we had KeyError when accessing the `float(grade_data["Grades"][self.get_survey_score_id()])` index within the `models.py.max_score()` method to calculate the `raw_possible` value.