### PR TITLE
Pulled the score category ID using the Name value for Sumac.

### DIFF
--- a/qualtricssurvey/models.py
+++ b/qualtricssurvey/models.py
@@ -71,7 +71,7 @@ class CourseDetailsXBlockMixin(object):
                 try:
                     qs_course_term = block_iter.other_course_settings['qualtrics_term']
                 except:
-                    LOGGER.error("QualtricsXblock – No qualtrics term found in other_course_settings")
+                    LOGGER.error("QualtricsXblock - No qualtrics term found in other_course_settings")
             
             block_iter = block_iter.get_parent() if block_iter.parent else None
 
@@ -836,10 +836,7 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, O
         """
         Locate the Qualtrics `Score Id` in site configuration or general settings.
         """
-        # score_id = configuration_helpers.get_value(
-        #         "QUALTRICS_SCORE_ID", settings.QUALTRICS_SCORE_ID
-        #     )
-        return QualtricsApi(self.your_university).get_survey_score_id()
+        return QualtricsApi(self.your_university).get_survey_score_id(self.get_survey_id())
     
     def max_score(self):
         """
@@ -874,6 +871,7 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, O
 
         if self.should_send_qualtrics_score_to_platform():
             # Find score values from Qualtrics
+            score_id = self.get_survey_score_id()
 
             # Get the number of questions from the Qualtrics Survey Definition Questions
             # endpoint and find all questions with score value set.
@@ -888,14 +886,15 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, O
                     if question["GradingData"] and question["QuestionID"] not in exclude_question_ids:
                         for grade_data in question["GradingData"]:
                             try:
-                                raw_possible += float(grade_data["Grades"][self.get_survey_score_id()])
+                                if score_id is not None and score_id in grade_data["Grades"]:
+                                    raw_possible += float(grade_data["Grades"][score_id])
                             except ValueError as err:
                                 # Sometimes we may forget to set a score grading value and `#` will get passed from Qualtrics.
-                                LOGGER.warning(u"Qualtrics – max_score() – Issue with getting raw_possible for – Survey ID ({}) QID ({}) GradingData({}) – {}".format(self.get_survey_id(), question["QuestionID"], grade_data["Grades"][self.get_survey_score_id()], err))
+                                LOGGER.warning(u"Qualtrics - max_score() - Issue with getting raw_possible for - Survey ID ({}) QID ({}) GradingData({}) - {}".format(self.get_survey_id(), question["QuestionID"], grade_data["Grades"][score_id], err))
                                 continue
                             except KeyError as err:
                                 # Sometimes we may forget to set a score grading value and `#` will get passed from Qualtrics.
-                                LOGGER.warning(u"Qualtrics – max_score() – Issue with getting raw_possible for – Survey ID ({}) QID ({}) – {}".format(self.get_survey_id(), question["QuestionID"], err))
+                                LOGGER.warning(u"Qualtrics - max_score() - Issue with getting raw_possible for - Survey ID ({}) QID ({}) - {}".format(self.get_survey_id(), question["QuestionID"], err))
                                 continue
         else:
             # Awards full points for completing a survey (default)
@@ -1018,7 +1017,9 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, O
         if self.should_send_qualtrics_score_to_platform():
             # Find score values from Qualtrics
             if values is not None:
-                raw_earned = float(values[self.get_survey_score_id()])
+                score_id = self.get_survey_score_id()
+                if score_id is not None and score_id in values:
+                    raw_earned = float(values[score_id])
         else:
             # Awards full points for completing a survey (default)
             raw_earned = (self.weight if self.weight is not None and self.weight > 0 else 1.0)

--- a/qualtricssurvey/qualtrics_api.py
+++ b/qualtricssurvey/qualtrics_api.py
@@ -145,6 +145,7 @@ class QualtricsApi():
             LOGGER.error(u"QualtricsApi – Issue with get_survey_definition() – Survey ID ({})".format(survey_id)) 
 
         return response_survey_definition
+
     def get_survey_definition_questions(self, survey_id):
         """
         Retrieve survey definition questions
@@ -184,11 +185,48 @@ class QualtricsApi():
 
     #     return response_survey
 
-    def get_survey_score_id(self):
+    def get_survey_score_id(self, survey_id):
         """
         Locate the Qualtrics `Score Id` in configuration settings.
         """
-        return self._get_api_config_setting('QUALTRICS_SCORE_ID')
+        score_id = None
+        category_name = self._get_api_config_setting('QUALTRICS_SCORE_CATEGORY_NAME')
+
+        response_survey_definition = self.get_survey_definition(survey_id)
+        if response_survey_definition.ok:    
+            data_response_survey_definition = response_survey_definition.json()
+            result = data_response_survey_definition["result"]
+            categories = result.get("Scoring", {}).get("ScoringCategories", [])
+
+            # Qualtrics currently returns ScoringCategories as a list.
+            if isinstance(categories, list):
+                category_items = categories
+            elif isinstance(categories, dict):
+                category_items = categories.values()
+            else:
+                category_items = []
+
+            score_id = next(
+                (
+                    cat.get("ID")
+                    for cat in category_items
+                    if isinstance(cat, dict) and cat.get("Name") == category_name
+                ),
+                None,
+            )
+        
+        if score_id is None:
+            LOGGER.error(
+                u"QualtricsApi - get_survey_score_id() - Score category '{}' not found in survey '{}'".format(
+                    category_name, survey_id
+                )
+            )
+
+        LOGGER.info(u"QualtricsApi - get_survey_score_id() - Located score_id '{}' for category '{}' in survey '{}'".format(
+            score_id, category_name, survey_id
+        ))
+
+        return score_id
 
     def get_oauth_token(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path, walk
 from setuptools import setup
 
 
-version = '2.1.4'
+version = '2.1.5'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:


### PR DESCRIPTION
Each Qualtrics survey could have a unique Score category ID value. Most default with Name "Score" for the score category. So instead of configuring Qualtrics to a specific Score category ID, we'll use Qualtrics API 'survey-definition' to retrieve the Score category ID by Name and define that name in the Qualtrics configuration as `QUALTRICS_SCORE_CATEGORY_NAME`.
