### PR TITLE
Only show points when the Qualtrics component is in a graded subsection for Sumac.

### DIFF
--- a/qualtricssurvey/models.py
+++ b/qualtricssurvey/models.py
@@ -435,7 +435,7 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, O
     """
     survey_completed = False
 
-    editable_fields = [
+    editable_field_names = (
         'display_name',
         'survey_id',
         'your_university',
@@ -458,7 +458,7 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, O
         'show_simulation_exists',
         'show_meta_information',
         'weight'
-    ]
+    )
     course_id_override = String(
         display_name=_('Course Identifier:'),
         default='',
@@ -814,7 +814,23 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, O
         """
         Return True/False to indicate whether to "Send Qualtrics Score to Platform" information.
         """
-        return self.send_qualtrics_score_to_platform
+        return self.send_qualtrics_score_to_platform and getattr(self, 'graded', False)
+
+    @property
+    def editable_fields(self):
+        """
+        Return Studio-editable fields, hiding score-to-platform setting when ungraded.
+        """
+        editable_fields = list(self.editable_field_names)
+
+        if not getattr(self, 'graded', False):
+            editable_fields = [
+                field_name
+                for field_name in editable_fields
+                if field_name != 'send_qualtrics_score_to_platform'
+            ]
+
+        return tuple(editable_fields)
 
     def should_show_simulation_exists(self):
         """
@@ -959,11 +975,15 @@ class QualtricsSurveyModelMixin(ScorableXBlockMixin, CourseDetailsXBlockMixin, O
                     # rebinds the user to the xblock so that a grade can be published for the correct user
                     self.system.rebind_noauth_module_to_user(self, real_user)
 
-                    score = self.calculate_score(values)
-                    self.set_score(score)
-                    self.publish_grade()
-                
+                    if self.should_send_qualtrics_score_to_platform():
+                        score = self.calculate_score(values)
+                        self.set_score(score)
+                        self.publish_grade()
+                    else:
+                        self.score = None
+
                     # Updates database survey status to complete
+                    # This is the Completion API call that will mark the survey as completed for the learner in the platform.
                     self.is_answered = True
                 else:
                     LOGGER.warning(

--- a/qualtricssurvey/static/html/view.html
+++ b/qualtricssurvey/static/html/view.html
@@ -1,10 +1,12 @@
 <div class="qualtricssurvey_block">
     <div class="qualtrics_message"> 
         <div class="grade">
-          <span class="earned_score">{{earned_score}}</span>/<span class="possible_score">{{possible_score}}</span> points 
+          <span class="grade_points" style="display:none;">
+            <span class="earned_score">{{earned_score}}</span>/<span class="possible_score">{{possible_score}}</span> points
+          </span>
           <span class = "is_graded"></span><span class="status"></span>
         </div>
         <p>{{message}}</p>
     </div>
-    <iframe src="https://{{your_university}}.qualtrics.com/jfe/form/{{survey_id}}?{{lms_root_url}}&amp;{{block_location_id}}&amp;{{course_id_string}}&amp;{{course_name_string}}&amp;{{course_org_string}}&amp;{{course_number_string}}&amp;{{course_run_string}}&amp;{{course_term_string}}&amp;{{course_start_date_string}}&amp;{{course_end_date_string}}&amp;{{course_institution_string}}&amp;{{course_instructor_string}}&amp;{{course_module_name_string}}&amp;{{forward_platform_user_pii}}&amp;{{forward_platform_user_demographic_data}}&amp;{{forward_course_organization_data}}&amp;{{show_simulation_exists_string}}&amp;{{show_meta_information_string}}&amp;{{anon_user_id_string}}" height="1000px"></iframe>
+    <iframe src="https://{{your_university}}.qualtrics.com/jfe/form/{{survey_id}}?{{lms_root_url}}&amp;{{block_location_id}}&amp;{{course_id_string}}&amp;{{course_name_string}}&amp;{{course_org_string}}&amp;{{course_number_string}}&amp;{{course_run_string}}&amp;{{course_term_string}}&amp;{{course_start_date_string}}&amp;{{course_end_date_string}}&amp;{{course_institution_string}}&amp;{{course_instructor_string}}&amp;{{course_module_name_string}}&amp;{{forward_platform_user_pii}}&amp;{{forward_platform_user_demographic_data}}&amp;{{forward_course_organization_data}}&amp;{{show_simulation_exists_string}}&amp;{{show_meta_information_string}}&amp;{{anon_user_id_string}}&amp;{{gradeable_subsection_string}}" height="1000px"></iframe>
 </div>

--- a/qualtricssurvey/static/js/view.js
+++ b/qualtricssurvey/static/js/view.js
@@ -21,10 +21,12 @@ function QualtricsSurveyView(runtime, element) {
   // To find elements inside your XBlock, try:
   // var myElement = $element.find('.myElement');
   
-  var earned_score_html = $('.qualtricssurvey_block .qualtrics_message .grade .earned_score')
-  var possible_score_html = $('.qualtricssurvey_block .qualtrics_message .grade .possible_score')
-  var status_html = $('.qualtricssurvey_block .qualtrics_message .grade .status')
-  var graded_html = $('.qualtricssurvey_block .qualtrics_message .grade .is_graded')
+  var grade_html = $element.find('.qualtrics_message .grade')
+  var grade_points_html = $element.find('.qualtrics_message .grade .grade_points')
+  var earned_score_html = $element.find('.qualtrics_message .grade .earned_score')
+  var possible_score_html = $element.find('.qualtrics_message .grade .possible_score')
+  var status_html = $element.find('.qualtrics_message .grade .status')
+  var graded_html = $element.find('.qualtrics_message .grade .is_graded')
   
   var handlerUrl = runtime.handlerUrl(element, 'get_survey_status');
 
@@ -35,16 +37,23 @@ function QualtricsSurveyView(runtime, element) {
         url: runtime.handlerUrl(element, 'is_graded'),
         data: '{}',
         success: function (data) {
-          $element.find(graded_html).text(
-            data.graded ? '(Graded) ' : '(Ungraded) ' 
-          );
+          if (data.graded) {
+            graded_html.text('(Graded) ')
+            grade_points_html.show()
+            updateView()
+          }
+          else {
+            // For ungraded subsections, show only the ungraded label.
+            grade_html.text('(Ungraded)')
+            grade_points_html.hide()
+          }
         },
         dataType: 'json'
     });
   }
 
   /* Regularly check to see if score was received and display to the learner */
-  function updateView(event) {
+  function updateView() {
     setTimeout(function() { 
       $.ajax({
         method: "POST",
@@ -52,9 +61,9 @@ function QualtricsSurveyView(runtime, element) {
         data: JSON.stringify({}),
         success: function (data) {
           if (data.is_answered == true) {
-            $element.find(earned_score_html).text(data.earned_score.toFixed(1))
-            $element.find(possible_score_html).text(data.possible_score.toFixed(1))
-            $element.find(status_html).addClass("fa fa-check-circle graded")
+            earned_score_html.text(data.earned_score.toFixed(1))
+            possible_score_html.text(data.possible_score.toFixed(1))
+            status_html.addClass("fa fa-check-circle graded")
           }
           else {
             updateView()
@@ -65,5 +74,4 @@ function QualtricsSurveyView(runtime, element) {
   }
 
   updateGradedStatus();
-  updateView();
 }

--- a/qualtricssurvey/views.py
+++ b/qualtricssurvey/views.py
@@ -127,6 +127,10 @@ class QualtricsSurveyViewMixin(
         show_meta_information_string = ("display_meta={param_display_meta}").format(
             param_display_meta=param_display_meta,
         )
+        param_gradeable_subsection = True if getattr(self, 'graded', False) else False
+        gradeable_subsection_string = ("gradeable_subsection={param_gradeable_subsection}").format(
+            param_gradeable_subsection=param_gradeable_subsection,
+        )
         param_survey_completed = 'The survey is done' if self.survey_completed else 'Please continue to finish the survey'
 
         context.update({
@@ -153,6 +157,7 @@ class QualtricsSurveyViewMixin(
             'forward_course_organization_data': forward_course_organization_data_string.strip(),
             'show_simulation_exists_string': show_simulation_exists_string.strip(),
             'show_meta_information_string': show_meta_information_string.strip(),
+            'gradeable_subsection_string': gradeable_subsection_string.strip(),
             'message': self.message,
             'survey_completed': param_survey_completed,
             'anon_user_id_string': anon_user_id_string,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path, walk
 from setuptools import setup
 
 
-version = '2.1.5'
+version = '2.1.6'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:


### PR DESCRIPTION
To prevent confusion for the learners, we'll need to limit view of points to only show when the Qualtrics component is in a gradeable subsection.

Also prevent publishing the score from Qualtrics to the platform when the Qualtrics component is in an ungradeable subsection.
